### PR TITLE
remove unsupported `sha256 :no_check`

### DIFF
--- a/Formula/googerteller.rb
+++ b/Formula/googerteller.rb
@@ -1,6 +1,5 @@
 class Googerteller < Formula
-  sha256 :no_check
-  
+
   desc "googerteller"
   homepage "https://github.com/berthubert/googerteller"
   head "https://github.com/berthubert/googerteller.git", branch: "main"


### PR DESCRIPTION
A recent update to homebrew breaks `sha256 :no_check` for formulae. Evidently this was never supported but didn't cause `brew` to blow up until recently.

Here's a GH issue discussion that gives more information
https://github.com/Homebrew/brew/issues/17175